### PR TITLE
Fail setup on CI

### DIFF
--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -14,7 +14,16 @@ function setup_deps {
     return $exit_code
 }
 
-if setup_deps; then
+setup_deps
+status=$?
+
+if [ $status -eq 0 ]; then
     echo "Dependencies set up, clearing log file to avoid confusing the agent."
     > "$setup_deps_output"
 fi
+
+if [ "${CI:-}" = "1" ]; then
+    exit $status
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- exit non-zero in `.agent/setup.sh` when CI=1

## Testing
- `bash -n .agent/setup.sh`