### PR TITLE
Fix build issues with C++20 and BusyBee

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ AM_CFLAGS    = -fvisibility=hidden $(WANAL_CFLAGS)
 AM_CXXFLAGS  = -fvisibility=hidden -fvisibility-inlines-hidden $(PO6_CFLAGS) $(E_CFLAGS) $(BUSYBEE_CFLAGS) $(HYPERLEVELDB_CFLAGS) $(REPLICANT_CFLAGS) $(MACAROONS_CFLAGS) $(TREADSTONE_CFLAGS) $(WANAL_CXXFLAGS)
 AM_MAKEFLAGS = --no-print-directory
 AM_YFLAGS = -d
+PANDOC ?= pandoc
 HELP2MAN_FLAGS = --no-discard-stderr --libtool --no-info --version-string=$(VERSION) --manual="HyperDex User Manual"
 TESTS_ENVIRONMENT = . $(abs_top_srcdir)/test/env.sh "${abs_top_srcdir}" "${abs_top_builddir}" "${VERSION}";
 AM_DISTCHECK_CONFIGURE_FLAGS = --enable-python-bindings
@@ -81,7 +82,7 @@ TESTS =
 ################################################################################
 
 %.h2m: %.md
-	$(pandoc_verbose)pandoc -s -w man -o $@ $<
+        $(pandoc_verbose)$(PANDOC) -s -w man -o $@ $<
 	$(sed_verbose)sed -e 's/^\.SH \(.*\)$$/[\1]/' -e 's/^.PP$$//' $@ > $@.tmp
 	@mv $@.tmp $@
 

--- a/admin/admin.cc
+++ b/admin/admin.cc
@@ -62,7 +62,7 @@ using hyperdex::admin;
 admin :: admin(const char* coordinator, uint16_t port)
     : m_coord(replicant_client_create(coordinator, port))
     , m_busybee_mapper(&m_config)
-    , m_busybee(&m_busybee_mapper, 0)
+    , m_busybee(busybee_client::create(&m_busybee_mapper))
     , m_config()
     , m_config_id(-1)
     , m_config_status()
@@ -844,7 +844,6 @@ admin :: loop(int timeout, hyperdex_admin_returncode* status)
             case BUSYBEE_SUCCESS:
                 break;
             case BUSYBEE_SEE_ERRNO:
-            case BUSYBEE_SEE_ERRNO:
                 ERROR(POLLFAILED) << "poll failed";
                 return -1;
             case BUSYBEE_DISRUPTED:
@@ -1088,7 +1087,6 @@ admin :: send(network_msgtype mt,
             handle_disruption(id);
             ERROR(SERVERERROR) << "server " << id.get() << " had a communication disruption";
             return false;
-        case BUSYBEE_SEE_ERRNO:
         case BUSYBEE_SEE_ERRNO:
             ERROR(POLLFAILED) << "poll failed";
             return false;

--- a/admin/raw_backup.cc
+++ b/admin/raw_backup.cc
@@ -64,7 +64,7 @@ hyperdex_admin_raw_backup(const char* host, uint16_t port,
             return -1;
         }
 
-        busybee_single bbs(loc);
+        std::auto_ptr<busybee_single> bbs(busybee_single::create(loc));
         const uint8_t type = static_cast<uint8_t>(BACKUP);
         const uint8_t flags = 0;
         const uint64_t version = 0;
@@ -82,9 +82,7 @@ hyperdex_admin_raw_backup(const char* host, uint16_t port,
         std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
         e::packer pa = msg->pack_at(BUSYBEE_HEADER_SIZE);
         pa = pa << type << flags << version << to << nonce << name_s;
-        bbs.set_timeout(-1);
-
-        switch (bbs.send(msg))
+        switch (bbs->send(msg))
         {
             case BUSYBEE_SUCCESS:
                 break;
@@ -97,7 +95,6 @@ hyperdex_admin_raw_backup(const char* host, uint16_t port,
             case BUSYBEE_SHUTDOWN:
             case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_DISRUPTED:
-            case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_EXTERNAL:
                 *status = HYPERDEX_ADMIN_SERVERERROR;
                 return -1;
@@ -105,7 +102,7 @@ hyperdex_admin_raw_backup(const char* host, uint16_t port,
                 abort();
         }
 
-        switch (bbs.recv(&msg))
+        switch (bbs->recv(-1, &msg))
         {
             case BUSYBEE_SUCCESS:
                 break;
@@ -118,7 +115,6 @@ hyperdex_admin_raw_backup(const char* host, uint16_t port,
             case BUSYBEE_SHUTDOWN:
             case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_DISRUPTED:
-            case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_EXTERNAL:
                 *status = HYPERDEX_ADMIN_SERVERERROR;
                 return -1;

--- a/client/client.cc
+++ b/client/client.cc
@@ -38,7 +38,7 @@
 #include <e/strescape.h>
 
 // BusyBee
-#include <busybee_utils.h>
+#include <busybee.h>
 
 // HyperDex
 #include "visibility.h"

--- a/daemon/communication.cc
+++ b/daemon/communication.cc
@@ -172,7 +172,6 @@ communication :: send_client(const virtual_server_id& from,
                 return false;
             case BUSYBEE_SHUTDOWN:
             case BUSYBEE_SEE_ERRNO:
-            case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_TIMEOUT:
             case BUSYBEE_EXTERNAL:
             case BUSYBEE_INTERRUPTED:
@@ -228,7 +227,6 @@ communication :: send(const virtual_server_id& from,
                 handle_disruption(to.get());
                 return false;
             case BUSYBEE_SHUTDOWN:
-            case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_TIMEOUT:
             case BUSYBEE_EXTERNAL:
@@ -286,7 +284,6 @@ communication :: send(const virtual_server_id& from,
                 return false;
             case BUSYBEE_SHUTDOWN:
             case BUSYBEE_SEE_ERRNO:
-            case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_TIMEOUT:
             case BUSYBEE_EXTERNAL:
             case BUSYBEE_INTERRUPTED:
@@ -336,7 +333,6 @@ communication :: send(const virtual_server_id& vto,
                 handle_disruption(to.get());
                 return false;
             case BUSYBEE_SHUTDOWN:
-            case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_TIMEOUT:
             case BUSYBEE_EXTERNAL:
@@ -394,7 +390,6 @@ communication :: send_exact(const virtual_server_id& from,
                 return false;
             case BUSYBEE_SHUTDOWN:
             case BUSYBEE_SEE_ERRNO:
-            case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_TIMEOUT:
             case BUSYBEE_EXTERNAL:
             case BUSYBEE_INTERRUPTED:
@@ -438,7 +433,6 @@ communication :: recv(e::garbage_collector::thread_state* ts,
                 continue;
             case BUSYBEE_INTERRUPTED:
                 continue;
-            case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_SEE_ERRNO:
             case BUSYBEE_TIMEOUT:
             case BUSYBEE_EXTERNAL:

--- a/daemon/datalayer.h
+++ b/daemon/datalayer.h
@@ -203,14 +203,13 @@ class datalayer
         returncode handle_error(leveldb::Status st);
         void collect_lower_checkpoints(uint64_t checkpoint_gc);
 
-        const static region_id defaultri;
-        static uint64_t id(region_id ri) { return ri.get(); }
+        static uint64_t id_u64(uint64_t ri) { return ri; }
 
     private:
         daemon* m_daemon;
         leveldb_db_ptr m_db;
         std::vector<index_state> m_indices;
-        e::ao_hash_map<region_id, uint64_t, id, defaultri> m_versions;
+        e::ao_hash_map<uint64_t, uint64_t, id_u64, 0> m_versions;
         const std::auto_ptr<checkpointer_thread> m_checkpointer;
         const std::auto_ptr<wiper_indexer_mediator> m_mediator;
         const std::auto_ptr<indexer_thread> m_indexer;

--- a/daemon/identifier_collector.cc
+++ b/daemon/identifier_collector.cc
@@ -37,7 +37,6 @@
 using hyperdex::identifier_collector;
 using hyperdex::region_id;
 
-const region_id identifier_collector::defaultri;
 
 identifier_collector :: identifier_collector(e::garbage_collector* gc)
     : m_gc(gc)
@@ -54,7 +53,7 @@ identifier_collector :: bump(const region_id& ri, uint64_t lb)
 {
     e::compat::shared_ptr<e::seqno_collector> sc;
 
-    if (!m_collectors.get(ri, &sc))
+    if (!m_collectors.get(ri.get(), &sc))
     {
         abort();
     }
@@ -67,7 +66,7 @@ identifier_collector :: collect(const region_id& ri, uint64_t seqno)
 {
     e::compat::shared_ptr<e::seqno_collector> sc;
 
-    if (!m_collectors.get(ri, &sc))
+    if (!m_collectors.get(ri.get(), &sc))
     {
         abort();
     }
@@ -80,7 +79,7 @@ identifier_collector :: lower_bound(const region_id& ri)
 {
     e::compat::shared_ptr<e::seqno_collector> sc;
 
-    if (!m_collectors.get(ri, &sc))
+    if (!m_collectors.get(ri.get(), &sc))
     {
         abort();
     }
@@ -99,14 +98,14 @@ identifier_collector :: adopt(region_id* ris, size_t ris_sz)
     {
         e::compat::shared_ptr<e::seqno_collector> sc;
 
-        if (!m_collectors.get(ris[i], &sc))
+        if (!m_collectors.get(ris[i].get(), &sc))
         {
             sc = e::compat::shared_ptr<e::seqno_collector>(new e::seqno_collector(m_gc));
             sc->collect(0);
         }
 
         assert(sc);
-        new_collectors.put(ris[i], sc);
+        new_collectors.put(ris[i].get(), sc);
     }
 
     m_collectors.swap(&new_collectors);

--- a/daemon/identifier_collector.h
+++ b/daemon/identifier_collector.h
@@ -63,11 +63,10 @@ class identifier_collector
     private:
         identifier_collector(const identifier_collector&);
         identifier_collector& operator = (const identifier_collector&);
-        static uint64_t id(region_id ri) { return ri.get(); }
+        static uint64_t id(uint64_t ri) { return ri; }
 
     private:
-        const static region_id defaultri;
-        typedef e::ao_hash_map<region_id, e::compat::shared_ptr<e::seqno_collector>, id, defaultri> collector_map_t;
+        typedef e::ao_hash_map<uint64_t, e::compat::shared_ptr<e::seqno_collector>, id, 0> collector_map_t;
         e::garbage_collector* m_gc;
         collector_map_t m_collectors;
 };

--- a/daemon/identifier_generator.cc
+++ b/daemon/identifier_generator.cc
@@ -38,7 +38,6 @@ using namespace e::atomic;
 using hyperdex::identifier_generator;
 using hyperdex::region_id;
 
-const region_id identifier_generator::defaultri;
 
 identifier_generator :: identifier_generator()
     : m_generators()
@@ -54,7 +53,7 @@ identifier_generator :: bump(const region_id& ri, uint64_t id)
 {
     uint64_t* val = NULL;
 
-    if (!m_generators.mod(ri, &val))
+    if (!m_generators.mod(ri.get(), &val))
     {
         return false;
     }
@@ -75,7 +74,7 @@ identifier_generator :: peek(const region_id& ri) const
     e::atomic::memory_barrier();
     uint64_t val = 0;
 
-    if (!m_generators.get(ri, &val))
+    if (!m_generators.get(ri.get(), &val))
     {
         abort();
     }
@@ -88,7 +87,7 @@ identifier_generator :: generate_id(const region_id& ri)
 {
     uint64_t* val = NULL;
 
-    if (!m_generators.mod(ri, &val))
+    if (!m_generators.mod(ri.get(), &val))
     {
         abort();
     }
@@ -105,12 +104,12 @@ identifier_generator :: adopt(region_id* ris, size_t ris_sz)
     {
         uint64_t count = 0;
 
-        if (!m_generators.get(ris[i], &count))
+        if (!m_generators.get(ris[i].get(), &count))
         {
             count = 1;
         }
 
-        new_generators.put(ris[i], count);
+        new_generators.put(ris[i].get(), count);
     }
 
     m_generators.swap(&new_generators);

--- a/daemon/identifier_generator.h
+++ b/daemon/identifier_generator.h
@@ -63,11 +63,10 @@ class identifier_generator
     private:
         identifier_generator(const identifier_generator&);
         identifier_generator& operator = (const identifier_generator&);
-        static uint64_t hashid(region_id ri) { return ri.get(); }
+        static uint64_t hashid(uint64_t ri) { return ri; }
 
     private:
-        const static region_id defaultri;
-        typedef e::ao_hash_map<region_id, uint64_t, hashid, defaultri> generator_map_t;
+        typedef e::ao_hash_map<uint64_t, uint64_t, hashid, 0> generator_map_t;
         generator_map_t m_generators;
 };
 

--- a/daemon/main.cc
+++ b/daemon/main.cc
@@ -41,7 +41,7 @@
 #include <e/popt.h>
 
 // BusyBee
-#include <busybee_utils.h>
+#include <busybee.h>
 
 // HyperDex
 #include "daemon/daemon.h"


### PR DESCRIPTION
## Summary
- adjust datalayer and identifier maps to avoid using class-typed NTTPs
- update BusyBee includes and API usage
- fix build rules for man pages via `PANDOC` variable

## Testing
- `make -j4 PANDOC=true` *(fails: BUSYBEE_POLLFAILED, etc.)*
