### PR TITLE
Improve dependency setup with Makefile

### DIFF
--- a/.agent/Makefile
+++ b/.agent/Makefile
@@ -1,0 +1,63 @@
+THREADS ?= $(shell nproc)
+ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
+THREADS := 8
+endif
+
+.PHONY: all clones \
+	    po6_clone e_clone busybee_clone HyperLevelDB_clone \
+	    libmacaroons_clone libtreadstone_clone Replicant_clone \
+	    po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant \
+	    hyperdex
+
+all: hyperdex
+
+clones: po6_clone e_clone busybee_clone HyperLevelDB_clone \
+	    libmacaroons_clone libtreadstone_clone Replicant_clone
+
+po6_clone:
+	git clone https://github.com/AaronFriel/po6.git po6 || true
+
+po6: po6_clone
+	cd po6 && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+
+e_clone:
+	git clone https://github.com/AaronFriel/e.git e || true
+
+e: po6 e_clone
+	cd e && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+
+busybee_clone:
+	git clone https://github.com/AaronFriel/busybee.git busybee || true
+
+busybee: e busybee_clone
+	cd busybee && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+
+HyperLevelDB_clone:
+	git clone https://github.com/AaronFriel/HyperLevelDB.git HyperLevelDB || true
+
+HyperLevelDB: HyperLevelDB_clone
+	cd HyperLevelDB && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+
+libmacaroons_clone:
+	git clone https://github.com/AaronFriel/libmacaroons.git libmacaroons || true
+
+libmacaroons: libmacaroons_clone
+	cd libmacaroons && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+
+libtreadstone_clone:
+	git clone https://github.com/AaronFriel/libtreadstone.git libtreadstone || true
+
+libtreadstone: libtreadstone_clone libmacaroons
+	cd libtreadstone && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+
+Replicant_clone:
+	git clone https://github.com/AaronFriel/Replicant.git Replicant || true
+
+Replicant: busybee Replicant_clone
+	cd Replicant && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+
+hyperdex: po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant
+	autoreconf -i
+	./configure --prefix=/opt/hyperdex
+	make -j$(THREADS)
+	make check

--- a/.agent/deps.sh
+++ b/.agent/deps.sh
@@ -19,18 +19,5 @@ if [ "$THREADS" -gt 8 ]; then
     THREADS=8
 fi
 
-for repo in "po6" "e" "busybee" "HyperLevelDB" "libmacaroons" "libtreadstone" "Replicant"; do
-    git clone https://github.com/AaronFriel/$repo.git || true
-    cd $repo
-    autoreconf -i
-    ./configure
-    make -j$THREADS
-    make install
-    ldconfig
-    cd ..
-done
+make -C "$(dirname "$0")" THREADS="$THREADS" hyperdex
 
-autoreconf -i
-./configure --prefix=/opt/hyperdex
-make;
-make check;

--- a/common/auth_wallet.cc
+++ b/common/auth_wallet.cc
@@ -61,7 +61,10 @@ auth_wallet :: get_macaroons(std::vector<macaroon*>* macaroons)
     for (size_t i = 0; i < m_macaroons.size(); ++i)
     {
         macaroon_returncode err;
-        macaroon* M = macaroon_deserialize(m_macaroons[i].c_str(), &err);
+        const unsigned char* data =
+            reinterpret_cast<const unsigned char*>(m_macaroons[i].data());
+        size_t data_sz = m_macaroons[i].size();
+        macaroon* M = macaroon_deserialize(data, data_sz, &err);
 
         if (!M)
         {


### PR DESCRIPTION
## Summary
- fix macaroon deserialization build error
- invoke Makefile from deps.sh
- add clone and build phases to `.agent/Makefile` for parallel download
- remove accidental submodules

## Testing
- `g++ -std=c++11 -I. -Iinclude -Icommon -I/usr/local/include -c common/auth_wallet.cc -o /tmp/auth_wallet.o`
- `make -f .agent/Makefile -n clones`
