### PR TITLE
Fix CI double run triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- only run CI on pushes to master and all PRs

## Testing
- `sudo ./.agent/setup.sh` *(fails: couldn't clone po6)*