### PR TITLE
Install pandoc in agent setup

### DIFF
--- a/.agent/deps.sh
+++ b/.agent/deps.sh
@@ -7,7 +7,7 @@ apt update -y;
 apt install -y build-essential autoconf automake libtool pkg-config \
     libgoogle-glog-dev libleveldb-dev libpopt-dev \
     libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
-    libsparsehash-dev \
+    libsparsehash-dev pandoc \
     libbsd-dev \
     autoconf-archive;
 


### PR DESCRIPTION
## Summary
- add `pandoc` to the list of packages installed in `.agent/deps.sh`

## Testing
- `bash .agent/setup.sh` *(fails: apt cannot update packages in this environment)*