### PR TITLE
Fix busybee includes and update API usage

### DIFF
--- a/admin/admin.cc
+++ b/admin/admin.cc
@@ -34,7 +34,7 @@
 #include <e/endian.h>
 
 // BusyBee
-#include <busybee_constants.h>
+#include <busybee.h>
 
 // HyperDex
 #include <hyperdex/hyperspace_builder.h>
@@ -62,7 +62,7 @@ using hyperdex::admin;
 admin :: admin(const char* coordinator, uint16_t port)
     : m_coord(replicant_client_create(coordinator, port))
     , m_busybee_mapper(&m_config)
-    , m_busybee(&m_busybee_mapper, 0)
+    , m_busybee(busybee_client::create(&m_busybee_mapper))
     , m_config()
     , m_config_id(-1)
     , m_config_status()
@@ -82,7 +82,7 @@ admin :: admin(const char* coordinator, uint16_t port)
     , m_pcs()
     , m_last_error()
 {
-    m_busybee.set_external_fd(replicant_client_poll_fd(m_coord));
+    m_busybee->set_external_fd(replicant_client_poll_fd(m_coord));
 }
 
 admin :: ~admin() throw ()
@@ -770,6 +770,7 @@ admin :: loop(int timeout, hyperdex_admin_returncode* status)
         }
 
         assert(!m_coord_ops.empty() || !m_server_ops.empty() || m_pcs);
+        int busybee_timeout = timeout;
 
         if (m_pcs)
         {
@@ -783,22 +784,22 @@ admin :: loop(int timeout, hyperdex_admin_returncode* status)
 
             if (timeout > t)
             {
-                m_busybee.set_timeout(t);
+                busybee_timeout = t;
                 timeout -= t;
             }
             else if (timeout < 0)
             {
-                m_busybee.set_timeout(t);
+                busybee_timeout = t;
             }
             else
             {
-                m_busybee.set_timeout(timeout);
+                busybee_timeout = timeout;
                 timeout = 0;
             }
         }
         else
         {
-            m_busybee.set_timeout(timeout);
+            busybee_timeout = timeout;
         }
 
         if (m_handle_coord_ops)
@@ -834,15 +835,14 @@ admin :: loop(int timeout, hyperdex_admin_returncode* status)
 
         uint64_t sid_num;
         std::auto_ptr<e::buffer> msg;
-        busybee_returncode rc = m_busybee.recv(&sid_num, &msg);
+        busybee_returncode rc = m_busybee->recv(busybee_timeout, &sid_num, &msg);
         server_id id(sid_num);
 
         switch (rc)
         {
             case BUSYBEE_SUCCESS:
                 break;
-            case BUSYBEE_POLLFAILED:
-            case BUSYBEE_ADDFDFAIL:
+            case BUSYBEE_SEE_ERRNO:
                 ERROR(POLLFAILED) << "poll failed";
                 return -1;
             case BUSYBEE_DISRUPTED:
@@ -1075,9 +1075,7 @@ admin :: send(network_msgtype mt,
     const uint64_t version = m_config.version();
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << type << flags << version << uint64_t(UINT64_MAX) << nonce;
-    m_busybee.set_timeout(-1);
-
-    switch (m_busybee.send(id.get(), msg))
+    switch (m_busybee->send(id.get(), msg))
     {
         case BUSYBEE_SUCCESS:
             op->handle_sent_to(id);
@@ -1087,8 +1085,7 @@ admin :: send(network_msgtype mt,
             handle_disruption(id);
             ERROR(SERVERERROR) << "server " << id.get() << " had a communication disruption";
             return false;
-        case BUSYBEE_POLLFAILED:
-        case BUSYBEE_ADDFDFAIL:
+        case BUSYBEE_SEE_ERRNO:
             ERROR(POLLFAILED) << "poll failed";
             return false;
         case BUSYBEE_SHUTDOWN:
@@ -1120,7 +1117,7 @@ admin :: handle_disruption(const server_id& si)
         }
     }
 
-    m_busybee.drop(si.get());
+    m_busybee->reset();
 }
 
 HYPERDEX_API std::ostream&

--- a/admin/admin.h
+++ b/admin/admin.h
@@ -33,9 +33,10 @@
 // STL
 #include <map>
 #include <list>
+#include <memory>
 
 // BusyBee
-#include <busybee_st.h>
+#include <busybee.h>
 
 // Replicant
 #include <replicant.h>
@@ -151,7 +152,7 @@ class admin
     private:
         replicant_client* m_coord;
         mapper m_busybee_mapper;
-        busybee_st m_busybee;
+        const std::auto_ptr<busybee_client> m_busybee;
         // configuration
         configuration m_config;
         int64_t m_config_id;

--- a/admin/constants.h
+++ b/admin/constants.h
@@ -29,7 +29,7 @@
 #define hyperdex_admin_constants_h_
 
 // BusyBee
-#include <busybee_constants.h>
+#include <busybee.h>
 
 #define HYPERDEX_ADMIN_HEADER_SIZE_REQ (BUSYBEE_HEADER_SIZE \
                                         + sizeof(uint8_t) /*mt*/ \

--- a/admin/raw_backup.cc
+++ b/admin/raw_backup.cc
@@ -34,8 +34,7 @@
 #include <po6/net/hostname.h>
 
 // BusyBee
-#include <busybee_constants.h>
-#include <busybee_single.h>
+#include <busybee.h>
 
 // HyperDex
 #include <hyperdex/admin.h>
@@ -83,8 +82,6 @@ hyperdex_admin_raw_backup(const char* host, uint16_t port,
         std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
         e::packer pa = msg->pack_at(BUSYBEE_HEADER_SIZE);
         pa = pa << type << flags << version << to << nonce << name_s;
-        bbs.set_timeout(-1);
-
         switch (bbs.send(msg))
         {
             case BUSYBEE_SUCCESS:
@@ -106,7 +103,7 @@ hyperdex_admin_raw_backup(const char* host, uint16_t port,
                 abort();
         }
 
-        switch (bbs.recv(&msg))
+        switch (bbs.recv(-1, &msg))
         {
             case BUSYBEE_SUCCESS:
                 break;

--- a/client/client.cc
+++ b/client/client.cc
@@ -83,7 +83,7 @@ using hyperdex::microtransaction;
 client :: client(const char* coordinator, uint16_t port)
     : m_coord(replicant_client_create(coordinator, port))
     , m_busybee_mapper(&m_config)
-    , m_busybee(&m_busybee_mapper, 0)
+    , m_busybee(busybee_client::create(&m_busybee_mapper))
     , m_config()
     , m_config_id(-1)
     , m_config_status()
@@ -108,14 +108,14 @@ client :: client(const char* coordinator, uint16_t port)
         throw std::bad_alloc();
     }
 
-    m_busybee.set_external_fd(replicant_client_poll_fd(m_coord));
-    m_busybee.set_external_fd(m_flagfd.poll_fd());
+    m_busybee->set_external_fd(replicant_client_poll_fd(m_coord));
+    m_busybee->set_external_fd(m_flagfd.poll_fd());
 }
 
 client :: client(const char* conn_str)
     : m_coord(replicant_client_create_conn_str(conn_str))
     , m_busybee_mapper(&m_config)
-    , m_busybee(&m_busybee_mapper, 0)
+    , m_busybee(busybee_client::create(&m_busybee_mapper))
     , m_config()
     , m_config_id(-1)
     , m_config_status()
@@ -140,8 +140,8 @@ client :: client(const char* conn_str)
         throw std::bad_alloc();
     }
 
-    m_busybee.set_external_fd(replicant_client_poll_fd(m_coord));
-    m_busybee.set_external_fd(m_flagfd.poll_fd());
+    m_busybee->set_external_fd(replicant_client_poll_fd(m_coord));
+    m_busybee->set_external_fd(m_flagfd.poll_fd());
 }
 
 client :: ~client() throw ()
@@ -554,8 +554,7 @@ client :: loop(int timeout, hyperdex_client_returncode* status)
 
         uint64_t sid_num;
         std::auto_ptr<e::buffer> msg;
-        m_busybee.set_timeout(timeout);
-        busybee_returncode rc = m_busybee.recv(&sid_num, &msg);
+        busybee_returncode rc = m_busybee->recv(timeout, &sid_num, &msg);
         server_id id(sid_num);
 
         switch (rc)
@@ -640,8 +639,7 @@ client :: loop(int timeout, hyperdex_client_returncode* status)
     }
 
     uint64_t sid_num;
-    m_busybee.set_timeout(0);
-    busybee_returncode rc = m_busybee.recv_no_msg(&sid_num);
+    busybee_returncode rc = m_busybee->recv_no_msg(0, &sid_num);
 
     switch (rc)
     {
@@ -676,7 +674,7 @@ client :: loop(int timeout, hyperdex_client_returncode* status)
 int
 client :: poll_fd()
 {
-    return m_busybee.poll_fd();
+    return m_busybee->poll_fd();
 }
 
 void
@@ -696,7 +694,7 @@ int
 client :: block(int timeout)
 {
     pollfd pfd;
-    pfd.fd = m_busybee.poll_fd();
+    pfd.fd = m_busybee->poll_fd();
     pfd.events = POLLIN|POLLHUP;
     pfd.revents = 0;
     return ::poll(&pfd, 1, timeout) >= 0 ? 0 : -1;
@@ -1202,8 +1200,7 @@ client :: send(network_msgtype mt,
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << type << flags << version << to << nonce;
     server_id id = m_config.get_server_id(to);
-    m_busybee.set_timeout(-1);
-    busybee_returncode rc = m_busybee.send(id.get(), msg);
+    busybee_returncode rc = m_busybee->send(id.get(), msg);
 
     switch (rc)
     {
@@ -1280,7 +1277,7 @@ client :: handle_disruption(const server_id& si)
         }
     }
 
-    m_busybee.drop(si.get());
+    m_busybee->reset();
 }
 
 microtransaction* client::uxact_init(const char* space, hyperdex_client_returncode *status)

--- a/client/client.h
+++ b/client/client.h
@@ -33,9 +33,10 @@
 // STL
 #include <map>
 #include <list>
+#include <memory>
 
 // BusyBee
-#include <busybee_st.h>
+#include <busybee.h>
 
 // Replicant
 #include <replicant.h>
@@ -255,7 +256,7 @@ class client
     private:
         replicant_client* m_coord;
         mapper m_busybee_mapper;
-        busybee_st m_busybee;
+        const std::auto_ptr<busybee_client> m_busybee;
         // configuration
         configuration m_config;
         int64_t m_config_id;

--- a/client/constants.h
+++ b/client/constants.h
@@ -29,7 +29,7 @@
 #define hyperdex_client_constants_h_
 
 // BusyBee
-#include <busybee_constants.h>
+#include <busybee.h>
 
 #define HYPERDEX_CLIENT_HEADER_SIZE_REQ (BUSYBEE_HEADER_SIZE \
                                      + sizeof(uint8_t) /*mt*/ \


### PR DESCRIPTION
## Summary
- update BusyBee includes to use the new busybee.h header
- replace deprecated busybee_st with busybee_client and busybee_single
- adjust send/recv calls to the updated BusyBee API

## Testing
- `make -j$(nproc)` *(fails: admin/parse_space_l.l unknown error)*