### PR TITLE
Improve .agent dependency setup

### DIFF
--- a/.agent/deps.sh
+++ b/.agent/deps.sh
@@ -3,13 +3,18 @@
 set -euo pipefail
 set -x
 
-apt update -y;
+apt update -y
 apt install -y build-essential autoconf automake libtool pkg-config \
     libgoogle-glog-dev libleveldb-dev libpopt-dev \
     libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
     libsparsehash-dev \
     libbsd-dev \
-    autoconf-archive;
+    autoconf-archive &
+APT_PID=$!
+
+make -C "$(dirname "$0")" clones
+
+wait "$APT_PID"
 
 # libbsd-dev for libmacaroons
 

--- a/admin/parse_space_l.l
+++ b/admin/parse_space_l.l
@@ -66,8 +66,10 @@ columns(const char* text, int* column);
 %option reentrant
 %option bison-bridge
 %option bison-locations
-// Define yywrap to silence warning in reconfigure
+%{
+/* Define yywrap to silence warning in reconfigure */
 int yywrap(void) { return 1; }
+%}
 
 %%
 


### PR DESCRIPTION
## Summary
- fix `//` comment in `admin/parse_space_l.l` that broke flex
- run `apt install` in the background so repository clones can start immediately

## Testing
- `bash -n .agent/deps.sh`
- `flex -o admin/parse_space_l.c admin/parse_space_l.l`
- `bash .agent/deps.sh` *(fails: Could not connect to proxy for apt)*