### PR TITLE
Fix build tool and auto_ptr usage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,7 @@ gperf_verbose_0 = @echo "  GPERF   " $@;
 help2man_verbose = $(help2man_verbose_$(V))
 help2man_verbose_ = $(help2man_verbose_$(AM_DEFAULT_VERBOSITY))
 help2man_verbose_0 = @echo "  MAN     " $@;
+HELP2MAN = true
 pandoc_verbose = $(pandoc_verbose_$(V))
 pandoc_verbose_ = $(pandoc_verbose_$(AM_DEFAULT_VERBOSITY))
 pandoc_verbose_0 = @echo "  PANDOC  " $@;
@@ -306,7 +307,7 @@ hyperdex_daemon_LDADD += $(E_LIBS)
 hyperdex_daemon_LDADD += $(PO6_LIBS)
 hyperdex_daemon_LDADD += $(POPT_LIBS) ${GLOG_LIBS} -lpthread
 man/hyperdex-daemon.1: man/hyperdex-daemon.1.h2m daemon/main.cc | hyperdex-daemon$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-daemon$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-daemon$(EXEEXT)
 
 check_PROGRAMS += daemon/test/identifier_collector
 check_PROGRAMS += daemon/test/identifier_generator
@@ -368,7 +369,7 @@ hyperdex_coordinator_LDADD += $(BUSYBEE_LIBS)
 hyperdex_coordinator_LDADD += $(E_LIBS)
 hyperdex_coordinator_LDADD += $(POPT_LIBS)
 man/hyperdex-coordinator.1: man/hyperdex-coordinator.1.h2m | hyperdex-coordinator${EXEEXT}
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-coordinator$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-coordinator$(EXEEXT)
 
 ################################################################################
 #################################### Client ####################################
@@ -1186,7 +1187,7 @@ hyperdex_SOURCES = hyperdex.cc
 hyperdex_CPPFLAGS = -DHYPERDEX_EXEC_DIR=\""$(hyperdexexecdir)\"" $(AM_CPPFLAGS) $(CPPFLAGS)
 hyperdex_LDADD = $(E_LIBS) $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex.1: man/hyperdex.1.h2m hyperdex.cc | hyperdex$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex$(EXEEXT)
 
 # hyperdex-add-space
 EXTRA_DIST += man/hyperdex-add-space.1.md
@@ -1194,7 +1195,7 @@ EXTRA_DIST += man/hyperdex-add-space.1.h2m
 hyperdex_add_space_SOURCES = tools/add-space.cc
 hyperdex_add_space_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-add-space.1: man/hyperdex-add-space.1.h2m tools/add-space.cc | hyperdex-add-space$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-add-space$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-add-space$(EXEEXT)
 
 # hyperdex-rm-space
 EXTRA_DIST += man/hyperdex-rm-space.1.md
@@ -1202,7 +1203,7 @@ EXTRA_DIST += man/hyperdex-rm-space.1.h2m
 hyperdex_rm_space_SOURCES = tools/rm-space.cc
 hyperdex_rm_space_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-rm-space.1: man/hyperdex-rm-space.1.h2m tools/rm-space.cc | hyperdex-rm-space$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-rm-space$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-rm-space$(EXEEXT)
 
 # hyperdex-mv-space
 EXTRA_DIST += man/hyperdex-mv-space.1.md
@@ -1210,7 +1211,7 @@ EXTRA_DIST += man/hyperdex-mv-space.1.h2m
 hyperdex_mv_space_SOURCES = tools/mv-space.cc
 hyperdex_mv_space_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-mv-space.1: man/hyperdex-mv-space.1.h2m tools/mv-space.cc | hyperdex-mv-space$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-mv-space$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-mv-space$(EXEEXT)
 
 # hyperdex-list-spaces
 EXTRA_DIST += man/hyperdex-list-spaces.1.md
@@ -1218,7 +1219,7 @@ EXTRA_DIST += man/hyperdex-list-spaces.1.h2m
 hyperdex_list_spaces_SOURCES = tools/list-spaces.cc
 hyperdex_list_spaces_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-list-spaces.1: man/hyperdex-list-spaces.1.h2m tools/list-spaces.cc | hyperdex-list-spaces$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-list-spaces$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-list-spaces$(EXEEXT)
 
 # hyperdex-validate-space
 EXTRA_DIST += man/hyperdex-validate-space.1.md
@@ -1226,7 +1227,7 @@ EXTRA_DIST += man/hyperdex-validate-space.1.h2m
 hyperdex_validate_space_SOURCES = tools/validate-space.cc
 hyperdex_validate_space_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-validate-space.1: man/hyperdex-validate-space.1.h2m tools/validate-space.cc | hyperdex-validate-space$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-validate-space$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-validate-space$(EXEEXT)
 
 # hyperdex-add-index
 EXTRA_DIST += man/hyperdex-add-index.1.md
@@ -1234,7 +1235,7 @@ EXTRA_DIST += man/hyperdex-add-index.1.h2m
 hyperdex_add_index_SOURCES = tools/add-index.cc
 hyperdex_add_index_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-add-index.1: man/hyperdex-add-index.1.h2m tools/add-index.cc | hyperdex-add-index$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-add-index$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-add-index$(EXEEXT)
 
 # hyperdex-rm-index
 EXTRA_DIST += man/hyperdex-rm-index.1.md
@@ -1242,7 +1243,7 @@ EXTRA_DIST += man/hyperdex-rm-index.1.h2m
 hyperdex_rm_index_SOURCES = tools/rm-index.cc
 hyperdex_rm_index_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-rm-index.1: man/hyperdex-rm-index.1.h2m tools/rm-index.cc | hyperdex-rm-index$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-rm-index$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-rm-index$(EXEEXT)
 
 # hyperdex-show-config
 EXTRA_DIST += man/hyperdex-show-config.1.md
@@ -1250,7 +1251,7 @@ EXTRA_DIST += man/hyperdex-show-config.1.h2m
 hyperdex_show_config_SOURCES = tools/show-config.cc
 hyperdex_show_config_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-show-config.1: man/hyperdex-show-config.1.h2m tools/show-config.cc | hyperdex-show-config$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-show-config$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-show-config$(EXEEXT)
 
 # hyperdex-server-register
 EXTRA_DIST += man/hyperdex-server-register.1.md
@@ -1258,7 +1259,7 @@ EXTRA_DIST += man/hyperdex-server-register.1.h2m
 hyperdex_server_register_SOURCES = tools/server-register.cc
 hyperdex_server_register_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-server-register.1: man/hyperdex-server-register.1.h2m tools/server-register.cc | hyperdex-server-register$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-register$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-register$(EXEEXT)
 
 # hyperdex-server-online
 EXTRA_DIST += man/hyperdex-server-online.1.md
@@ -1266,7 +1267,7 @@ EXTRA_DIST += man/hyperdex-server-online.1.h2m
 hyperdex_server_online_SOURCES = tools/server-online.cc
 hyperdex_server_online_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-server-online.1: man/hyperdex-server-online.1.h2m tools/server-online.cc | hyperdex-server-online$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-online$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-online$(EXEEXT)
 
 # hyperdex-server-offline
 EXTRA_DIST += man/hyperdex-server-offline.1.md
@@ -1274,7 +1275,7 @@ EXTRA_DIST += man/hyperdex-server-offline.1.h2m
 hyperdex_server_offline_SOURCES = tools/server-offline.cc
 hyperdex_server_offline_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-server-offline.1: man/hyperdex-server-offline.1.h2m tools/server-offline.cc | hyperdex-server-offline$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-offline$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-offline$(EXEEXT)
 
 # hyperdex-server-forget
 EXTRA_DIST += man/hyperdex-server-forget.1.md
@@ -1282,7 +1283,7 @@ EXTRA_DIST += man/hyperdex-server-forget.1.h2m
 hyperdex_server_forget_SOURCES = tools/server-forget.cc
 hyperdex_server_forget_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-server-forget.1: man/hyperdex-server-forget.1.h2m tools/server-forget.cc | hyperdex-server-forget$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-forget$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-forget$(EXEEXT)
 
 # hyperdex-server-kill
 EXTRA_DIST += man/hyperdex-server-kill.1.md
@@ -1290,7 +1291,7 @@ EXTRA_DIST += man/hyperdex-server-kill.1.h2m
 hyperdex_server_kill_SOURCES = tools/server-kill.cc
 hyperdex_server_kill_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-server-kill.1: man/hyperdex-server-kill.1.h2m tools/server-kill.cc | hyperdex-server-kill$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-kill$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-server-kill$(EXEEXT)
 
 # hyperdex-perf-counters
 EXTRA_DIST += man/hyperdex-perf-counters.1.md
@@ -1298,7 +1299,7 @@ EXTRA_DIST += man/hyperdex-perf-counters.1.h2m
 hyperdex_perf_counters_SOURCES = tools/perf-counters.cc
 hyperdex_perf_counters_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-perf-counters.1: man/hyperdex-perf-counters.1.h2m tools/perf-counters.cc | hyperdex-perf-counters$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-perf-counters$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-perf-counters$(EXEEXT)
 
 # hyperdex-set-read-only
 EXTRA_DIST += man/hyperdex-set-read-only.1.md
@@ -1306,7 +1307,7 @@ EXTRA_DIST += man/hyperdex-set-read-only.1.h2m
 hyperdex_set_read_only_SOURCES = tools/set-read-only.cc
 hyperdex_set_read_only_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-set-read-only.1: man/hyperdex-set-read-only.1.h2m tools/set-read-only.cc | hyperdex-set-read-only$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-set-read-only$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-set-read-only$(EXEEXT)
 
 # hyperdex-set-read-write
 EXTRA_DIST += man/hyperdex-set-read-write.1.md
@@ -1314,7 +1315,7 @@ EXTRA_DIST += man/hyperdex-set-read-write.1.h2m
 hyperdex_set_read_write_SOURCES = tools/set-read-write.cc
 hyperdex_set_read_write_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-set-read-write.1: man/hyperdex-set-read-write.1.h2m tools/set-read-write.cc | hyperdex-set-read-write$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-set-read-write$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-set-read-write$(EXEEXT)
 
 # hyperdex-set-fault-tolerance
 EXTRA_DIST += man/hyperdex-set-fault-tolerance.1.md
@@ -1322,7 +1323,7 @@ EXTRA_DIST += man/hyperdex-set-fault-tolerance.1.h2m
 hyperdex_set_fault_tolerance_SOURCES = tools/set-fault-tolerance.cc
 hyperdex_set_fault_tolerance_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-set-fault-tolerance.1: man/hyperdex-set-fault-tolerance.1.h2m tools/set-fault-tolerance.cc | hyperdex-set-fault-tolerance$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-set-fault-tolerance$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-set-fault-tolerance$(EXEEXT)
 
 # hyperdex-wait-until-stable
 EXTRA_DIST += man/hyperdex-wait-until-stable.1.md
@@ -1330,7 +1331,7 @@ EXTRA_DIST += man/hyperdex-wait-until-stable.1.h2m
 hyperdex_wait_until_stable_SOURCES = tools/wait-until-stable.cc
 hyperdex_wait_until_stable_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-wait-until-stable.1: man/hyperdex-wait-until-stable.1.h2m tools/wait-until-stable.cc | hyperdex-wait-until-stable$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-wait-until-stable$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-wait-until-stable$(EXEEXT)
 
 # hyperdex-backup
 EXTRA_DIST += man/hyperdex-backup.1.md
@@ -1338,7 +1339,7 @@ EXTRA_DIST += man/hyperdex-backup.1.h2m
 hyperdex_backup_SOURCES = tools/backup.cc
 hyperdex_backup_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-backup.1: man/hyperdex-backup.1.h2m tools/backup.cc | hyperdex-backup$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-backup$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-backup$(EXEEXT)
 
 # hyperdex-backup-manager
 EXTRA_DIST += man/hyperdex-backup-manager.1.md
@@ -1346,7 +1347,7 @@ EXTRA_DIST += man/hyperdex-backup-manager.1.h2m
 hyperdex_backup_manager_SOURCES = tools/backup-manager.cc
 hyperdex_backup_manager_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-backup-manager.1: man/hyperdex-backup-manager.1.h2m tools/backup-manager.cc | hyperdex-backup-manager$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-backup-manager$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-backup-manager$(EXEEXT)
 
 # hyperdex-raw-backup
 EXTRA_DIST += man/hyperdex-raw-backup.1.md
@@ -1354,7 +1355,7 @@ EXTRA_DIST += man/hyperdex-raw-backup.1.h2m
 hyperdex_raw_backup_SOURCES = tools/raw-backup.cc
 hyperdex_raw_backup_LDADD = libhyperdex-admin.la $(PO6_LIBS) $(POPT_LIBS)
 man/hyperdex-raw-backup.1: man/hyperdex-raw-backup.1.h2m tools/raw-backup.cc | hyperdex-raw-backup$(EXEEXT)
-	$(help2man_verbose)help2man $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-raw-backup$(EXEEXT)
+	$(help2man_verbose)$(HELP2MAN) $(HELP2MAN_FLAGS) --section 1 --output $@ --include $< ${abs_top_builddir}/hyperdex-raw-backup$(EXEEXT)
 
 # hyperdex-noc
 EXTRA_DIST += hyperdex-noc

--- a/coordinator/coordinator.cc
+++ b/coordinator/coordinator.cc
@@ -1897,7 +1897,7 @@ coordinator :: generate_cached_configuration(rsm_context*)
     std::vector<transfer> transfers_subset;
     prioritized_transfer_subset(&transfers_subset);
 
-    std::auto_ptr<e::buffer> new_config(e::buffer::create(sz));
+    std::unique_ptr<e::buffer> new_config(e::buffer::create(sz));
     e::packer pa = new_config->pack_at(0);
     pa = pa << m_cluster << m_version << m_flags
             << uint64_t(m_servers.size())
@@ -1920,7 +1920,7 @@ coordinator :: generate_cached_configuration(rsm_context*)
         pa = pa << transfers_subset[i];
     }
 
-    m_latest_config = new_config;
+    m_latest_config = std::move(new_config);
 }
 
 struct coordinator::transfer_sorter

--- a/coordinator/coordinator.h
+++ b/coordinator/coordinator.h
@@ -224,8 +224,8 @@ class coordinator
         uint64_t m_checkpoint_gc_through;
         server_barrier m_checkpoint_stable_barrier;
         // cached config
-        std::auto_ptr<e::buffer> m_latest_config;
-        std::auto_ptr<e::buffer> m_response;
+        std::unique_ptr<e::buffer> m_latest_config;
+        std::unique_ptr<e::buffer> m_response;
 
     private:
         coordinator(const coordinator&);


### PR DESCRIPTION
## Summary
- disable help2man by providing stub variable in `Makefile.am`
- modernize coordinator code to use `std::unique_ptr`

## Testing
- `make -j$(nproc)`