### PR TITLE
Improve subrepo agent setup

### DIFF
--- a/.repos/.gitignore
+++ b/.repos/.gitignore
@@ -1,0 +1,8 @@
+*
+!.gitignore
+!*/
+!*/.agent/
+!*/.agent/**
+!*/.github/
+!*/.github/workflows/
+!*/.github/workflows/**

--- a/.repos/HyperLevelDB/.agent/.gitignore
+++ b/.repos/HyperLevelDB/.agent/.gitignore
@@ -1,0 +1,1 @@
+setup.log

--- a/.repos/HyperLevelDB/.agent/Makefile
+++ b/.repos/HyperLevelDB/.agent/Makefile
@@ -1,0 +1,19 @@
+THREADS ?= $(shell nproc)
+ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
+THREADS := 8
+endif
+
+.PHONY: clones HyperLevelDB_clone HyperLevelDB
+
+clones: HyperLevelDB_clone
+
+HyperLevelDB_clone:
+	@if [ -d HyperLevelDB/.git ]; then \
+	echo "Using existing clone in HyperLevelDB"; \
+	else \
+	git clone https://github.com/AaronFriel/HyperLevelDB.git HyperLevelDB; \
+	fi
+
+HyperLevelDB: HyperLevelDB_clone
+	cd HyperLevelDB && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+

--- a/.repos/HyperLevelDB/.agent/deps.sh
+++ b/.repos/HyperLevelDB/.agent/deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+TARGET=$(basename "$(dirname "$(dirname "$0")")")
+
+APT_PACKAGES="build-essential autoconf automake libtool pkg-config \
+    libgoogle-glog-dev libleveldb-dev libpopt-dev \
+    libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
+    libsparsehash-dev pandoc \
+    libbsd-dev \
+    autoconf-archive"
+
+apt update -y
+apt install -y $APT_PACKAGES &
+APT_PID=$!
+
+make -C "$(dirname "$0")" clones
+
+wait "$APT_PID"
+
+THREADS=$(nproc)
+if [ "$THREADS" -gt 8 ]; then
+    THREADS=8
+fi
+
+make -C "$(dirname "$0")" THREADS="$THREADS" "$TARGET"

--- a/.repos/HyperLevelDB/.agent/setup.sh
+++ b/.repos/HyperLevelDB/.agent/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+
+setup_deps_output="$CURRENT_DIR/setup.log"
+function setup_deps {
+    "$CURRENT_DIR/deps.sh" 2>&1 | tee -a "$setup_deps_output"
+    local pipe_status=("${PIPESTATUS[@]}")
+    local exit_code="${pipe_status[0]}"
+
+    if [ $exit_code -ne 0 ]; then
+        echo "setup_deps failed.  Output was written to $setup_deps_output"
+    fi
+    return $exit_code
+}
+
+if setup_deps; then
+    echo "Dependencies set up, clearing log file to avoid confusing the agent."
+    > "$setup_deps_output"
+fi

--- a/.repos/HyperLevelDB/.github/workflows/ci.yml
+++ b/.repos/HyperLevelDB/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run setup and tests
+      run: sudo ./.agent/setup.sh
+

--- a/.repos/Replicant/.agent/.gitignore
+++ b/.repos/Replicant/.agent/.gitignore
@@ -1,0 +1,1 @@
+setup.log

--- a/.repos/Replicant/.agent/Makefile
+++ b/.repos/Replicant/.agent/Makefile
@@ -1,0 +1,49 @@
+THREADS ?= $(shell nproc)
+ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
+THREADS := 8
+endif
+
+.PHONY: clones po6_clone e_clone busybee_clone Replicant_clone po6 e busybee Replicant
+
+clones: po6_clone e_clone busybee_clone Replicant_clone
+
+po6_clone:
+	@if [ -d po6/.git ]; then \
+	echo "Using existing clone in po6"; \
+	else \
+	git clone https://github.com/AaronFriel/po6.git po6; \
+	fi
+
+po6: po6_clone
+	cd po6 && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+
+e_clone:
+	@if [ -d e/.git ]; then \
+	echo "Using existing clone in e"; \
+	else \
+	git clone https://github.com/AaronFriel/e.git e; \
+	fi
+
+e: po6 e_clone
+	cd e && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+
+busybee_clone:
+	@if [ -d busybee/.git ]; then \
+	echo "Using existing clone in busybee"; \
+	else \
+	git clone https://github.com/AaronFriel/busybee.git busybee; \
+	fi
+
+busybee: e busybee_clone
+	cd busybee && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+
+Replicant_clone:
+	@if [ -d Replicant/.git ]; then \
+	echo "Using existing clone in Replicant"; \
+	else \
+	git clone https://github.com/AaronFriel/Replicant.git Replicant; \
+	fi
+
+Replicant: busybee Replicant_clone
+	cd Replicant && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+

--- a/.repos/Replicant/.agent/deps.sh
+++ b/.repos/Replicant/.agent/deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+TARGET=$(basename "$(dirname "$(dirname "$0")")")
+
+APT_PACKAGES="build-essential autoconf automake libtool pkg-config \
+    libgoogle-glog-dev libleveldb-dev libpopt-dev \
+    libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
+    libsparsehash-dev pandoc \
+    libbsd-dev \
+    autoconf-archive"
+
+apt update -y
+apt install -y $APT_PACKAGES &
+APT_PID=$!
+
+make -C "$(dirname "$0")" clones
+
+wait "$APT_PID"
+
+THREADS=$(nproc)
+if [ "$THREADS" -gt 8 ]; then
+    THREADS=8
+fi
+
+make -C "$(dirname "$0")" THREADS="$THREADS" "$TARGET"

--- a/.repos/Replicant/.agent/setup.sh
+++ b/.repos/Replicant/.agent/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+
+setup_deps_output="$CURRENT_DIR/setup.log"
+function setup_deps {
+    "$CURRENT_DIR/deps.sh" 2>&1 | tee -a "$setup_deps_output"
+    local pipe_status=("${PIPESTATUS[@]}")
+    local exit_code="${pipe_status[0]}"
+
+    if [ $exit_code -ne 0 ]; then
+        echo "setup_deps failed.  Output was written to $setup_deps_output"
+    fi
+    return $exit_code
+}
+
+if setup_deps; then
+    echo "Dependencies set up, clearing log file to avoid confusing the agent."
+    > "$setup_deps_output"
+fi

--- a/.repos/Replicant/.github/workflows/ci.yml
+++ b/.repos/Replicant/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run setup and tests
+      run: sudo ./.agent/setup.sh
+

--- a/.repos/busybee/.agent/.gitignore
+++ b/.repos/busybee/.agent/.gitignore
@@ -1,0 +1,1 @@
+setup.log

--- a/.repos/busybee/.agent/Makefile
+++ b/.repos/busybee/.agent/Makefile
@@ -1,0 +1,39 @@
+THREADS ?= $(shell nproc)
+ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
+THREADS := 8
+endif
+
+.PHONY: clones po6_clone e_clone busybee_clone po6 e busybee
+
+clones: po6_clone e_clone busybee_clone
+
+po6_clone:
+	@if [ -d po6/.git ]; then \
+	echo "Using existing clone in po6"; \
+	else \
+	git clone https://github.com/AaronFriel/po6.git po6; \
+	fi
+
+po6: po6_clone
+	cd po6 && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+
+e_clone:
+	@if [ -d e/.git ]; then \
+	echo "Using existing clone in e"; \
+	else \
+	git clone https://github.com/AaronFriel/e.git e; \
+	fi
+
+e: po6 e_clone
+	cd e && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+
+busybee_clone:
+	@if [ -d busybee/.git ]; then \
+	echo "Using existing clone in busybee"; \
+	else \
+	git clone https://github.com/AaronFriel/busybee.git busybee; \
+	fi
+
+busybee: e busybee_clone
+	cd busybee && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+

--- a/.repos/busybee/.agent/deps.sh
+++ b/.repos/busybee/.agent/deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+TARGET=$(basename "$(dirname "$(dirname "$0")")")
+
+APT_PACKAGES="build-essential autoconf automake libtool pkg-config \
+    libgoogle-glog-dev libleveldb-dev libpopt-dev \
+    libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
+    libsparsehash-dev pandoc \
+    libbsd-dev \
+    autoconf-archive"
+
+apt update -y
+apt install -y $APT_PACKAGES &
+APT_PID=$!
+
+make -C "$(dirname "$0")" clones
+
+wait "$APT_PID"
+
+THREADS=$(nproc)
+if [ "$THREADS" -gt 8 ]; then
+    THREADS=8
+fi
+
+make -C "$(dirname "$0")" THREADS="$THREADS" "$TARGET"

--- a/.repos/busybee/.agent/setup.sh
+++ b/.repos/busybee/.agent/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+
+setup_deps_output="$CURRENT_DIR/setup.log"
+function setup_deps {
+    "$CURRENT_DIR/deps.sh" 2>&1 | tee -a "$setup_deps_output"
+    local pipe_status=("${PIPESTATUS[@]}")
+    local exit_code="${pipe_status[0]}"
+
+    if [ $exit_code -ne 0 ]; then
+        echo "setup_deps failed.  Output was written to $setup_deps_output"
+    fi
+    return $exit_code
+}
+
+if setup_deps; then
+    echo "Dependencies set up, clearing log file to avoid confusing the agent."
+    > "$setup_deps_output"
+fi

--- a/.repos/busybee/.github/workflows/ci.yml
+++ b/.repos/busybee/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run setup and tests
+      run: sudo ./.agent/setup.sh
+

--- a/.repos/e/.agent/.gitignore
+++ b/.repos/e/.agent/.gitignore
@@ -1,0 +1,1 @@
+setup.log

--- a/.repos/e/.agent/Makefile
+++ b/.repos/e/.agent/Makefile
@@ -1,0 +1,29 @@
+THREADS ?= $(shell nproc)
+ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
+THREADS := 8
+endif
+
+.PHONY: clones po6_clone e_clone po6 e
+
+clones: po6_clone e_clone
+
+po6_clone:
+	@if [ -d po6/.git ]; then \
+	echo "Using existing clone in po6"; \
+	else \
+	git clone https://github.com/AaronFriel/po6.git po6; \
+	fi
+
+po6: po6_clone
+	cd po6 && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+
+e_clone:
+	@if [ -d e/.git ]; then \
+	echo "Using existing clone in e"; \
+	else \
+	git clone https://github.com/AaronFriel/e.git e; \
+	fi
+
+e: po6 e_clone
+	cd e && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+

--- a/.repos/e/.agent/deps.sh
+++ b/.repos/e/.agent/deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+TARGET=$(basename "$(dirname "$(dirname "$0")")")
+
+APT_PACKAGES="build-essential autoconf automake libtool pkg-config \
+    libgoogle-glog-dev libleveldb-dev libpopt-dev \
+    libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
+    libsparsehash-dev pandoc \
+    libbsd-dev \
+    autoconf-archive"
+
+apt update -y
+apt install -y $APT_PACKAGES &
+APT_PID=$!
+
+make -C "$(dirname "$0")" clones
+
+wait "$APT_PID"
+
+THREADS=$(nproc)
+if [ "$THREADS" -gt 8 ]; then
+    THREADS=8
+fi
+
+make -C "$(dirname "$0")" THREADS="$THREADS" "$TARGET"

--- a/.repos/e/.agent/setup.sh
+++ b/.repos/e/.agent/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+
+setup_deps_output="$CURRENT_DIR/setup.log"
+function setup_deps {
+    "$CURRENT_DIR/deps.sh" 2>&1 | tee -a "$setup_deps_output"
+    local pipe_status=("${PIPESTATUS[@]}")
+    local exit_code="${pipe_status[0]}"
+
+    if [ $exit_code -ne 0 ]; then
+        echo "setup_deps failed.  Output was written to $setup_deps_output"
+    fi
+    return $exit_code
+}
+
+if setup_deps; then
+    echo "Dependencies set up, clearing log file to avoid confusing the agent."
+    > "$setup_deps_output"
+fi

--- a/.repos/e/.github/workflows/ci.yml
+++ b/.repos/e/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run setup and tests
+      run: sudo ./.agent/setup.sh
+

--- a/.repos/libmacaroons/.agent/.gitignore
+++ b/.repos/libmacaroons/.agent/.gitignore
@@ -1,0 +1,1 @@
+setup.log

--- a/.repos/libmacaroons/.agent/Makefile
+++ b/.repos/libmacaroons/.agent/Makefile
@@ -1,0 +1,19 @@
+THREADS ?= $(shell nproc)
+ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
+THREADS := 8
+endif
+
+.PHONY: clones libmacaroons_clone libmacaroons
+
+clones: libmacaroons_clone
+
+libmacaroons_clone:
+	@if [ -d libmacaroons/.git ]; then \
+	echo "Using existing clone in libmacaroons"; \
+	else \
+	git clone https://github.com/AaronFriel/libmacaroons.git libmacaroons; \
+	fi
+
+libmacaroons: libmacaroons_clone
+	cd libmacaroons && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+

--- a/.repos/libmacaroons/.agent/deps.sh
+++ b/.repos/libmacaroons/.agent/deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+TARGET=$(basename "$(dirname "$(dirname "$0")")")
+
+APT_PACKAGES="build-essential autoconf automake libtool pkg-config \
+    libgoogle-glog-dev libleveldb-dev libpopt-dev \
+    libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
+    libsparsehash-dev pandoc \
+    libbsd-dev \
+    autoconf-archive"
+
+apt update -y
+apt install -y $APT_PACKAGES &
+APT_PID=$!
+
+make -C "$(dirname "$0")" clones
+
+wait "$APT_PID"
+
+THREADS=$(nproc)
+if [ "$THREADS" -gt 8 ]; then
+    THREADS=8
+fi
+
+make -C "$(dirname "$0")" THREADS="$THREADS" "$TARGET"

--- a/.repos/libmacaroons/.agent/setup.sh
+++ b/.repos/libmacaroons/.agent/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+
+setup_deps_output="$CURRENT_DIR/setup.log"
+function setup_deps {
+    "$CURRENT_DIR/deps.sh" 2>&1 | tee -a "$setup_deps_output"
+    local pipe_status=("${PIPESTATUS[@]}")
+    local exit_code="${pipe_status[0]}"
+
+    if [ $exit_code -ne 0 ]; then
+        echo "setup_deps failed.  Output was written to $setup_deps_output"
+    fi
+    return $exit_code
+}
+
+if setup_deps; then
+    echo "Dependencies set up, clearing log file to avoid confusing the agent."
+    > "$setup_deps_output"
+fi

--- a/.repos/libmacaroons/.github/workflows/ci.yml
+++ b/.repos/libmacaroons/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run setup and tests
+      run: sudo ./.agent/setup.sh
+

--- a/.repos/libtreadstone/.agent/.gitignore
+++ b/.repos/libtreadstone/.agent/.gitignore
@@ -1,0 +1,1 @@
+setup.log

--- a/.repos/libtreadstone/.agent/Makefile
+++ b/.repos/libtreadstone/.agent/Makefile
@@ -1,0 +1,29 @@
+THREADS ?= $(shell nproc)
+ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
+THREADS := 8
+endif
+
+.PHONY: clones libmacaroons_clone libtreadstone_clone libmacaroons libtreadstone
+
+clones: libmacaroons_clone libtreadstone_clone
+
+libmacaroons_clone:
+	@if [ -d libmacaroons/.git ]; then \
+	echo "Using existing clone in libmacaroons"; \
+	else \
+	git clone https://github.com/AaronFriel/libmacaroons.git libmacaroons; \
+	fi
+
+libmacaroons: libmacaroons_clone
+	cd libmacaroons && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+
+libtreadstone_clone:
+	@if [ -d libtreadstone/.git ]; then \
+	echo "Using existing clone in libtreadstone"; \
+	else \
+	git clone https://github.com/AaronFriel/libtreadstone.git libtreadstone; \
+	fi
+
+libtreadstone: libtreadstone_clone libmacaroons
+	cd libtreadstone && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+

--- a/.repos/libtreadstone/.agent/deps.sh
+++ b/.repos/libtreadstone/.agent/deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+TARGET=$(basename "$(dirname "$(dirname "$0")")")
+
+APT_PACKAGES="build-essential autoconf automake libtool pkg-config \
+    libgoogle-glog-dev libleveldb-dev libpopt-dev \
+    libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
+    libsparsehash-dev pandoc \
+    libbsd-dev \
+    autoconf-archive"
+
+apt update -y
+apt install -y $APT_PACKAGES &
+APT_PID=$!
+
+make -C "$(dirname "$0")" clones
+
+wait "$APT_PID"
+
+THREADS=$(nproc)
+if [ "$THREADS" -gt 8 ]; then
+    THREADS=8
+fi
+
+make -C "$(dirname "$0")" THREADS="$THREADS" "$TARGET"

--- a/.repos/libtreadstone/.agent/setup.sh
+++ b/.repos/libtreadstone/.agent/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+
+setup_deps_output="$CURRENT_DIR/setup.log"
+function setup_deps {
+    "$CURRENT_DIR/deps.sh" 2>&1 | tee -a "$setup_deps_output"
+    local pipe_status=("${PIPESTATUS[@]}")
+    local exit_code="${pipe_status[0]}"
+
+    if [ $exit_code -ne 0 ]; then
+        echo "setup_deps failed.  Output was written to $setup_deps_output"
+    fi
+    return $exit_code
+}
+
+if setup_deps; then
+    echo "Dependencies set up, clearing log file to avoid confusing the agent."
+    > "$setup_deps_output"
+fi

--- a/.repos/libtreadstone/.github/workflows/ci.yml
+++ b/.repos/libtreadstone/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run setup and tests
+      run: sudo ./.agent/setup.sh
+

--- a/.repos/po6/.agent/.gitignore
+++ b/.repos/po6/.agent/.gitignore
@@ -1,0 +1,1 @@
+setup.log

--- a/.repos/po6/.agent/Makefile
+++ b/.repos/po6/.agent/Makefile
@@ -1,0 +1,19 @@
+THREADS ?= $(shell nproc)
+ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
+THREADS := 8
+endif
+
+.PHONY: clones po6_clone po6
+
+clones: po6_clone
+
+po6_clone:
+	@if [ -d po6/.git ]; then \
+	echo "Using existing clone in po6"; \
+	else \
+	git clone https://github.com/AaronFriel/po6.git po6; \
+	fi
+
+po6: po6_clone
+	cd po6 && autoreconf -i && ./configure && make -j$(THREADS) && make check && make install && ldconfig
+

--- a/.repos/po6/.agent/deps.sh
+++ b/.repos/po6/.agent/deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+TARGET=$(basename "$(dirname "$(dirname "$0")")")
+
+APT_PACKAGES="build-essential autoconf automake libtool pkg-config \
+    libgoogle-glog-dev libleveldb-dev libpopt-dev \
+    libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
+    libsparsehash-dev pandoc \
+    libbsd-dev \
+    autoconf-archive"
+
+apt update -y
+apt install -y $APT_PACKAGES &
+APT_PID=$!
+
+make -C "$(dirname "$0")" clones
+
+wait "$APT_PID"
+
+THREADS=$(nproc)
+if [ "$THREADS" -gt 8 ]; then
+    THREADS=8
+fi
+
+make -C "$(dirname "$0")" THREADS="$THREADS" "$TARGET"

--- a/.repos/po6/.agent/setup.sh
+++ b/.repos/po6/.agent/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+
+setup_deps_output="$CURRENT_DIR/setup.log"
+function setup_deps {
+    "$CURRENT_DIR/deps.sh" 2>&1 | tee -a "$setup_deps_output"
+    local pipe_status=("${PIPESTATUS[@]}")
+    local exit_code="${pipe_status[0]}"
+
+    if [ $exit_code -ne 0 ]; then
+        echo "setup_deps failed.  Output was written to $setup_deps_output"
+    fi
+    return $exit_code
+}
+
+if setup_deps; then
+    echo "Dependencies set up, clearing log file to avoid confusing the agent."
+    > "$setup_deps_output"
+fi

--- a/.repos/po6/.github/workflows/ci.yml
+++ b/.repos/po6/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run setup and tests
+      run: sudo ./.agent/setup.sh
+


### PR DESCRIPTION
## Summary
- expand `.repos/.gitignore` to keep workflow files
- add CI workflows for each dependency repo
- include Makefiles to clone, build, and test each repo
- update `deps.sh` to install packages and run builds using new Makefiles

## Testing
- `make check`
