### PR TITLE
Fix artifact build directory

### DIFF
--- a/.agent/Makefile
+++ b/.agent/Makefile
@@ -86,6 +86,8 @@ Replicant: busybee Replicant_clone
 
 hyperdex: po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant
 	cd .. && autoreconf -i
-	cd .. && ./configure --prefix=/opt/hyperdex
-	$(MAKE) -C .. -j$(THREADS)
-	$(MAKE) -C .. check
+	rm -rf ../target && mkdir -p ../target
+	cd ../target && ../configure --prefix="$(pwd)/install"
+	$(MAKE) -C ../target -j$(THREADS)
+	$(MAKE) -C ../target check
+	$(MAKE) -C ../target install

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@
 /test/search-stress-test
 /test/simple-consistency-stress-test
 /ylwrap
+target/


### PR DESCRIPTION
## Summary
- install HyperDex build outputs to dedicated `target/install` directory
- add `make install` step to build script

## Testing
- `bash -n .agent/setup.sh`
- `bash -n .agent/deps.sh`
