### PR TITLE
Fix CI exit code for Codex agent

### DIFF
--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -22,8 +22,4 @@ if [ $status -eq 0 ]; then
     > "$setup_deps_output"
 fi
 
-if [ "${CODEX_AGENT:-0}" = "1" ]; then
-    exit $status
-else
-    exit 0
-fi
+exit $status

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -14,7 +14,16 @@ function setup_deps {
     return $exit_code
 }
 
-if setup_deps; then
+setup_deps
+status=$?
+
+if [ $status -eq 0 ]; then
     echo "Dependencies set up, clearing log file to avoid confusing the agent."
     > "$setup_deps_output"
+fi
+
+if [ "${CODEX_AGENT:-0}" = "1" ]; then
+    exit $status
+else
+    exit 0
 fi


### PR DESCRIPTION
## Summary
- avoid suppressing exit codes when running `setup.sh` if `CODEX_AGENT=1`
- restore simple `setup.sh` invocation in the CI workflow

## Testing
- `make check`
- `sudo ./.agent/setup.sh` *(fails: apt update network access)*