### PR TITLE
Upload HyperDex binaries in CI

### DIFF
--- a/.agent/Makefile
+++ b/.agent/Makefile
@@ -88,6 +88,7 @@ hyperdex: po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant
 	cd .. && autoreconf -i
 	rm -rf ../target && mkdir -p ../target
 	cd ../target && ../configure --prefix="$(pwd)/install"
+	mkdir -p ../target/man
 	$(MAKE) -C ../target -j$(THREADS)
 	$(MAKE) -C ../target check
 	$(MAKE) -C ../target install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run setup and tests
       run: sudo ./.agent/setup.sh
+    - name: Upload HyperDex binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: hyperdex-binaries
+        path: ./target
 


### PR DESCRIPTION
## Summary
- update agent build script to create the `man` directory
- upload the built `target` directory as a GitHub Actions artifact

## Testing
- `sudo ./.agent/setup.sh` *(fails: setup_deps failed)*