### PR TITLE
Fix build and update release workflow

### DIFF
--- a/.agent/Makefile
+++ b/.agent/Makefile
@@ -2,6 +2,11 @@ THREADS ?= $(shell nproc)
 ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
 THREADS := 8
 endif
+PREFIX ?= $(abspath ../target)
+export PKG_CONFIG_PATH := $(PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+export LD_LIBRARY_PATH := $(PREFIX)/lib:$(LD_LIBRARY_PATH)
+export CFLAGS := -I$(PREFIX)/include $(CFLAGS)
+export LDFLAGS := -L$(PREFIX)/lib $(LDFLAGS)
 
 .PHONY: all clones \
 	    po6_clone e_clone busybee_clone HyperLevelDB_clone \
@@ -22,7 +27,7 @@ po6_clone:
 	fi
 
 po6: po6_clone
-	cd po6 && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+	cd po6 && autoreconf -i && ./configure --prefix="$(PREFIX)" && make -j$(THREADS) && make install
 
 e_clone:
 	@if [ -d e/.git ]; then \
@@ -32,7 +37,7 @@ e_clone:
 	fi
 
 e: po6 e_clone
-	cd e && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+	cd e && autoreconf -i && ./configure --prefix="$(PREFIX)" && make -j$(THREADS) && make install
 
 busybee_clone:
 	@if [ -d busybee/.git ]; then \
@@ -42,7 +47,7 @@ busybee_clone:
 	fi
 
 busybee: e busybee_clone
-	cd busybee && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+	cd busybee && autoreconf -i && ./configure --prefix="$(PREFIX)" && make -j$(THREADS) && make install
 
 HyperLevelDB_clone:
 	@if [ -d HyperLevelDB/.git ]; then \
@@ -52,7 +57,7 @@ HyperLevelDB_clone:
 	fi
 
 HyperLevelDB: HyperLevelDB_clone
-	cd HyperLevelDB && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+	cd HyperLevelDB && autoreconf -i && ./configure --prefix="$(PREFIX)" && make -j$(THREADS) && make install
 
 libmacaroons_clone:
 	@if [ -d libmacaroons/.git ]; then \
@@ -62,7 +67,7 @@ libmacaroons_clone:
 	fi
 
 libmacaroons: libmacaroons_clone
-	cd libmacaroons && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+	cd libmacaroons && autoreconf -i && ./configure --prefix="$(PREFIX)" && make -j$(THREADS) && make install
 
 libtreadstone_clone:
 	@if [ -d libtreadstone/.git ]; then \
@@ -72,7 +77,7 @@ libtreadstone_clone:
 	fi
 
 libtreadstone: po6 e libtreadstone_clone
-	cd libtreadstone && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+	cd libtreadstone && autoreconf -i && ./configure --prefix="$(PREFIX)" && make -j$(THREADS) && make install
 
 Replicant_clone:
 	@if [ -d Replicant/.git ]; then \
@@ -82,11 +87,11 @@ Replicant_clone:
 	fi
 
 Replicant: busybee Replicant_clone
-	cd Replicant && autoreconf -i && ./configure && make -j$(THREADS) && make install && ldconfig
+	cd Replicant && autoreconf -i && ./configure --prefix="$(PREFIX)" && make -j$(THREADS) && make install
 
 hyperdex: po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant
 	cd .. && autoreconf -i
-	rm -rf ../target && mkdir -p ../target
+	mkdir -p ../target/man
 	cd ../target && ../configure --prefix="$(pwd)/install"
 	$(MAKE) -C ../target -j$(THREADS)
 	$(MAKE) -C ../target check

--- a/.agent/deps.sh
+++ b/.agent/deps.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 set -x
 
-apt update -y
-apt install -y build-essential autoconf automake libtool pkg-config \
+sudo apt update -y
+sudo apt install -y build-essential autoconf automake libtool pkg-config \
     libgoogle-glog-dev libleveldb-dev libpopt-dev \
     libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
     libsparsehash-dev pandoc \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,13 @@
-name: bump-patch-and-release
+name: build-bump-and-release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      commitish:
+        description: 'Commit SHA (leave blank for HEAD of main)'
+        required: false
+  pull_request:
 
 permissions: { contents: write }
 
@@ -12,33 +18,66 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
-      - uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const semver = require('semver');
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.inputs.commitish || github.sha }}
 
-            /* 1. Get previous release’s tag (404 if none) */
-            let prev = 'v0.0.0';
-            try {
-              const r = await github.rest.repos.getLatestRelease(context.repo);
-              prev = r.data.tag_name;
-            } catch (e) {
-              if (e.status !== 404) throw e;
-            }
+    - name: Compute next semantic-patch tag
+      id: bump
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        result-encoding: string
+        script: |
+          let prev = 'v0.0.0';
+          try {
+            const rel = await github.rest.repos.getLatestRelease(context.repo);
+            prev = rel.data.tag_name;
+          } catch (e) {
+            if (e.status !== 404) throw e;
+          }
+          const [maj = 0, min = 0, patch = 0] = prev.replace(/^v/, '').split('.').map(Number);
+          const next = `v${maj}.${min}.${patch + 1}`;
+          core.setOutput('next', next);
 
-            const next = 'v' + semver.inc(prev.replace(/^v/, ''), 'patch');
-            core.notice(`Next tag: ${next}`);
+    - name: Bootstrap build environment
+      run: bash .agent/setup.sh
 
-            /* 2. Create release (GitHub auto-creates a lightweight tag) */
-            await github.rest.repos.createRelease({
-              ...context.repo,
-              tag_name:          next,
-              target_commitish:  context.sha,
-              name:              next,
-              generate_release_notes: true,
-              draft:             true
-            });
+    - name: Build HyperDex
+      run: make -C .agent hyperdex
 
-            core.notice(`🎉 Published ${next} (tag + release)`);
+    - name: Create release tarball
+      id: pack
+      run: |
+        TAG=${{ steps.bump.outputs.next }}
+        tar -czf "hyperdex-${TAG}-linux-amd64.tar.gz" -C target/install .
+        echo "tarball=hyperdex-${TAG}-linux-amd64.tar.gz" >> "$GITHUB_OUTPUT"
+
+    - name: Tag & create release
+      id: release
+      env:
+        TAG: ${{ steps.bump.outputs.next }}
+        TARBALL: ${{ steps.pack.outputs.tarball }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        git config user.name  "GitHub Actions"
+        git config user.email "actions@github.com"
+        if [ "$EVENT_NAME" != "pull_request" ]; then
+          git tag "$TAG"
+          git push origin "$TAG"
+          DRAFT_FLAG="--draft=false"
+        else
+          DRAFT_FLAG="--draft"
+        fi
+        gh release create "$TAG" \
+          --title "HyperDex $TAG" \
+          --notes "Automated build of HyperDex $TAG" \
+          --verify-tag \
+          $DRAFT_FLAG \
+          "$TARBALL"


### PR DESCRIPTION
## Summary
- ensure `target/man` exists for out-of-tree builds
- extend release workflow to build and publish release artifacts
- install dependencies into `target` instead of system directories
- run setup script without `sudo`
- preserve locally installed libraries when building HyperDex

## Testing
- `make -C .agent lint-actions`


------
https://chatgpt.com/codex/tasks/task_e_685761f1bfe483208eec1b9cd26d89c5