### PR TITLE
Fix installation prefix path

### DIFF
--- a/.agent/Makefile
+++ b/.agent/Makefile
@@ -92,7 +92,7 @@ Replicant: busybee Replicant_clone
 hyperdex: po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant
 	cd .. && autoreconf -i
 	mkdir -p ../target/man
-	cd ../target && ../configure --prefix="$(pwd)/install"
+	cd ../target && ../configure --prefix="$(abspath ../target)/install"
 	$(MAKE) -C ../target -j$(THREADS)
 	$(MAKE) -C ../target check
 	$(MAKE) -C ../target install

--- a/.agent/Makefile
+++ b/.agent/Makefile
@@ -92,7 +92,7 @@ Replicant: busybee Replicant_clone
 hyperdex: po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant
 	cd .. && autoreconf -i
 	mkdir -p ../target/man
-	cd ../target && ../configure --prefix="$(abspath ../target)/install"
+	cd ../target && ../configure --prefix="$(PREFIX)/install"
 	$(MAKE) -C ../target -j$(THREADS)
 	$(MAKE) -C ../target check
 	$(MAKE) -C ../target install


### PR DESCRIPTION
## Summary
- ensure the build script sets a correct install prefix

## Testing
- `make -C .agent hyperdex` *(fails: cannot stat '../man/hyperdex-daemon.1')*

------
https://chatgpt.com/codex/tasks/task_e_6858a614ab7c832095461906cc0b79b6