### PR TITLE
Set reconfigure status when BusyBee send fails

### DIFF
--- a/client/client.cc
+++ b/client/client.cc
@@ -1201,6 +1201,10 @@ client :: send(network_msgtype mt,
     const uint8_t type = static_cast<uint8_t>(mt);
     const uint8_t flags = 0;
     const uint64_t version = m_config.version();
+    if (status)
+    {
+        *status = HYPERDEX_CLIENT_RECONFIGURE;
+    }
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << type << flags << version << to << nonce;
     server_id id = m_config.get_server_id(to);


### PR DESCRIPTION
## Summary
- set `HYPERDEX_CLIENT_RECONFIGURE` before BusyBee send attempts so failed sends cannot return a stale status
- keep the follow-up fix isolated from the earlier modern-toolchain and CI rollout changes

## Validation
- `make -C /home/friel/c/aaronfriel/hyhac-ci-lab/HyperDex/target client/client.lo libhyperdex-client.la client/test/datastructures`
