### PR TITLE
Fix admin loop and count aggregation regressions

### DIFF
--- a/admin/admin.cc
+++ b/admin/admin.cc
@@ -804,16 +804,34 @@ admin :: loop(int timeout, hyperdex_admin_returncode* status)
             recv_timeout = timeout;
         }
 
-        if (m_handle_coord_ops)
+        bool coord_only =
+            !m_handle_coord_ops &&
+            !m_coord_ops.empty() &&
+            m_server_ops.empty() &&
+            !m_pcs;
+
+        if (m_handle_coord_ops || coord_only)
         {
+            int coord_timeout = m_handle_coord_ops ? 0 : recv_timeout;
             m_handle_coord_ops = false;
             replicant_returncode lrc = REPLICANT_GARBAGE;
-            int64_t lid = replicant_client_loop(m_coord, 0, &lrc);
+            int64_t lid = replicant_client_loop(m_coord, coord_timeout, &lrc);
 
             if (lid < 0 && lrc != REPLICANT_TIMEOUT)
             {
                 interpret_replicant_returncode(lrc, status, &m_last_error);
                 return -1;
+            }
+
+            if (lid < 0 && lrc == REPLICANT_TIMEOUT)
+            {
+                if (coord_only)
+                {
+                    ERROR(TIMEOUT) << "operation timed out";
+                    return -1;
+                }
+
+                continue;
             }
 
             coord_rpc_map_t::iterator it = m_coord_ops.find(lid);

--- a/client/client.cc
+++ b/client/client.cc
@@ -1201,6 +1201,10 @@ client :: send(network_msgtype mt,
     const uint8_t type = static_cast<uint8_t>(mt);
     const uint8_t flags = 0;
     const uint64_t version = m_config.version();
+    if (status)
+    {
+        *status = HYPERDEX_CLIENT_RECONFIGURE;
+    }
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << type << flags << version << to << nonce;
     server_id id = m_config.get_server_id(to);

--- a/client/pending_count.cc
+++ b/client/pending_count.cc
@@ -105,7 +105,12 @@ pending_count :: handle_message(client* cl,
     }
 
     *m_count += local_count;
-    // Don't set the status or error so that errors will carry through.  It was
-    // set to the success state in the constructor
+
+    if (this->aggregation_done())
+    {
+        set_status(HYPERDEX_CLIENT_SUCCESS);
+        set_error(e::error());
+    }
+
     return true;
 }


### PR DESCRIPTION
## Summary
- fix coordinator-only admin waits so add-space and wait-until-stable complete again
- clear latched count reconfigure status once aggregation finishes successfully
- keep the existing CI and release flow unchanged

## Validation
- `make -C target client/client.lo libhyperdex-client.la hyperdex`
- native `hyperdex wait-until-stable` and `hyperdex add-space` probes against a fresh one-daemon cluster
- `HYPERDEX_ROOT=$(cd ../HyperDex/target && pwd) ../hyhac/.agent/check.sh` from the isolated workspace
