### PR TITLE
Add prek-based lint hooks and CI matrix

### DIFF
--- a/.agent/Makefile
+++ b/.agent/Makefile
@@ -8,13 +8,16 @@ export LD_LIBRARY_PATH := $(PREFIX)/lib:$(LD_LIBRARY_PATH)
 export CFLAGS := -I$(PREFIX)/include $(CFLAGS)
 export LDFLAGS := -L$(PREFIX)/lib $(LDFLAGS)
 
-.PHONY: all clones \
+.PHONY: all check clones \
 	    po6_clone e_clone busybee_clone HyperLevelDB_clone \
 	    libmacaroons_clone libtreadstone_clone Replicant_clone \
 	    po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant \
 	    hyperdex lint-actions
 
 all: hyperdex
+
+check:
+	./check.sh
 
 clones: po6_clone e_clone busybee_clone HyperLevelDB_clone \
 	    libmacaroons_clone libtreadstone_clone Replicant_clone
@@ -98,7 +101,4 @@ hyperdex: po6 e busybee HyperLevelDB libmacaroons libtreadstone Replicant
 	$(MAKE) -C ../target install dist_man_MANS=
 
 lint-actions:
-	@echo "Installing actionlint"
-	go install github.com/rhysd/actionlint/cmd/actionlint@latest
-	@echo "Running actionlint"
-	"$(shell go env GOPATH)/bin/actionlint"
+	../scripts/check-actions.sh

--- a/.agent/check.sh
+++ b/.agent/check.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/.." && pwd)
+
+export PATH="${HOME}/.local/bin:${PATH}"
+
+cd "${repo_root}"
+scripts/install-prek.sh
+prek run --all-files -c .pre-commit-config.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,9 @@ on:
   pull_request:
 
 jobs:
-  lint-actions:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
-      - name: Lint GitHub Actions
-        run: make -C .agent lint-actions
-
   setup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run setup and tests
         run: sudo ./.agent/setup.sh
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-prek-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Generate prek hook matrix
+        id: matrix
+        run: |
+          matrix="$(python3 scripts/list-prek-hooks.py)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "$matrix"
+
+  prek:
+    needs: prepare-prek-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-prek-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install prek
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          scripts/install-prek.sh
+
+      - name: Run prek hook
+        env:
+          PREK_HOOK_ID: ${{ matrix.id }}
+        run: prek run "$PREK_HOOK_ID" --all-files -c .pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: local
+    hooks:
+      - id: workflow-audit
+        name: github actions audit
+        entry: scripts/check-actions.sh
+        language: system
+        pass_filenames: false
+        files: ^\.github/workflows/.*\.ya?ml$
+
+      - id: shell-syntax
+        name: shell syntax
+        entry: scripts/check-shell-syntax.sh
+        language: system
+        pass_filenames: false
+        files: ^(\.agent|scripts|test|doc/install)/.*(\.sh)?$

--- a/scripts/check-actions.sh
+++ b/scripts/check-actions.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+cd "${repo_root}"
+
+if [ ! -d .github/workflows ]; then
+  echo "No .github/workflows directory found; skipping workflow audit."
+  exit 0
+fi
+
+actionlint_bin=$(scripts/install-actionlint.sh)
+"${actionlint_bin}"

--- a/scripts/check-shell-syntax.sh
+++ b/scripts/check-shell-syntax.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+shell_files=()
+search_roots=(.agent scripts test doc/install)
+
+cd "${repo_root}"
+
+for search_root in "${search_roots[@]}"; do
+  if [ ! -d "${search_root}" ]; then
+    continue
+  fi
+
+  while IFS= read -r path; do
+    shell_files+=("${path}")
+  done < <(find "${search_root}" -type f | sort)
+done
+
+shell_targets=()
+
+for path in "${shell_files[@]}"; do
+  first_line=$(head -n 1 "${path}" 2>/dev/null || true)
+  case "${path}:${first_line}" in
+    *.sh:*|*:'#!/bin/sh'*|*:'#!/usr/bin/env sh'*|*:'#!/bin/bash'*|*:'#!/usr/bin/env bash'*)
+      shell_targets+=("${path}")
+      ;;
+  esac
+done
+
+if [ "${#shell_targets[@]}" -eq 0 ]; then
+  echo "No shell files found."
+  exit 0
+fi
+
+bash -n "${shell_targets[@]}"

--- a/scripts/install-actionlint.sh
+++ b/scripts/install-actionlint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+actionlint_version=${ACTIONLINT_VERSION:-1.7.11}
+actionlint_sha256_linux_amd64=${ACTIONLINT_SHA256_LINUX_AMD64:-900919a84f2229bac68ca9cd4103ea297abc35e9689ebb842c6e34a3d1b01b0a}
+actionlint_bin=${ACTIONLINT_BIN:-}
+cache_root=${XDG_CACHE_HOME:-"${HOME}/.cache"}/HyperDex/tools
+actionlint_root="${cache_root}/actionlint/${actionlint_version}"
+
+cd "${repo_root}"
+
+if [ -n "${actionlint_bin}" ]; then
+  printf '%s\n' "${actionlint_bin}"
+  exit 0
+fi
+
+if command -v actionlint >/dev/null 2>&1; then
+  command -v actionlint
+  exit 0
+fi
+
+mkdir -p "${actionlint_root}"
+
+if [ ! -x "${actionlint_root}/actionlint" ]; then
+  archive=$(mktemp -t actionlint.XXXXXX.tar.gz)
+  trap 'rm -f "${archive}"' EXIT
+  curl -L --fail --silent --show-error \
+    "https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/actionlint_${actionlint_version}_linux_amd64.tar.gz" \
+    -o "${archive}"
+  printf '%s  %s\n' "${actionlint_sha256_linux_amd64}" "${archive}" | sha256sum --check --status
+  tar -xzf "${archive}" -C "${actionlint_root}" actionlint
+fi
+
+printf '%s\n' "${actionlint_root}/actionlint"

--- a/scripts/install-prek.sh
+++ b/scripts/install-prek.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+prek_version=${PREK_VERSION:-0.3.8}
+prek_sha256_x86_64_unknown_linux_gnu=${PREK_SHA256_X86_64_UNKNOWN_LINUX_GNU:-80ec6adb9f1883344de52cb943d371ecfd25340c4a6b5b81e2600d27e246cfa1}
+local_bin=${LOCAL_BIN:-"${HOME}/.local/bin"}
+
+cd "${repo_root}"
+
+if command -v prek >/dev/null 2>&1 && prek --version 2>/dev/null | grep -q "${prek_version}"; then
+  exit 0
+fi
+
+mkdir -p "${local_bin}"
+archive=$(mktemp -t prek.XXXXXX.tar.gz)
+trap 'rm -f "${archive}"' EXIT
+
+curl -L --fail --silent --show-error \
+  "https://github.com/j178/prek/releases/download/v${prek_version}/prek-x86_64-unknown-linux-gnu.tar.gz" \
+  -o "${archive}"
+printf '%s  %s\n' "${prek_sha256_x86_64_unknown_linux_gnu}" "${archive}" | sha256sum --check --status
+tar -xzf "${archive}" -C "${local_bin}" --strip-components=1 \
+  prek-x86_64-unknown-linux-gnu/prek
+chmod +x "${local_bin}/prek"

--- a/scripts/list-prek-hooks.py
+++ b/scripts/list-prek-hooks.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import json
+import re
+from pathlib import Path
+
+
+config_path = Path(".pre-commit-config.yaml")
+hook_id_re = re.compile(r"^\s*-\s+id:\s+(.+?)\s*$")
+stages_re = re.compile(r"^\s*stages:\s*\[(.*?)\]\s*$")
+
+
+def parse_hooks() -> list[dict[str, object]]:
+    hooks: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+
+    for raw_line in config_path.read_text().splitlines():
+        hook_match = hook_id_re.match(raw_line)
+        if hook_match:
+            if current is not None:
+                hooks.append(current)
+            current = {"id": hook_match.group(1), "stages": None}
+            continue
+
+        if current is None:
+            continue
+
+        stages_match = stages_re.match(raw_line)
+        if stages_match:
+            stages = [
+                stage.strip().strip("'\"")
+                for stage in stages_match.group(1).split(",")
+                if stage.strip()
+            ]
+            current["stages"] = stages
+
+    if current is not None:
+        hooks.append(current)
+
+    return hooks
+
+
+def main() -> None:
+    hooks = []
+    for hook in parse_hooks():
+        stages = hook["stages"]
+        if stages is not None and "pre-commit" not in stages:
+            continue
+        hooks.append({"id": hook["id"]})
+
+    print(json.dumps({"include": hooks}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a lightweight prek baseline for workflow lint and shell syntax
- expose a local check path that runs the repo hooks
- run the hooks as separate GitHub Actions jobs for faster feedback while preserving the existing build or integration jobs